### PR TITLE
Azure single server to flexible server

### DIFF
--- a/templates/shared_services/gitea/terraform/mysql.tf
+++ b/templates/shared_services/gitea/terraform/mysql.tf
@@ -11,7 +11,6 @@ resource "azurerm_mysql_flexible_server" "gitea" {
   resource_group_name          = local.core_resource_group_name
   location                     = data.azurerm_resource_group.rg.location
   administrator_login          = "mysqladmin"
-  administrator_login_password = random_password.password.result
   sku_name                     = local.sql_sku[var.sql_sku].value
   version                      = "8.0.21"
   backup_retention_days        = 7

--- a/templates/workspace_services/gitea/terraform/mysql.tf
+++ b/templates/workspace_services/gitea/terraform/mysql.tf
@@ -11,7 +11,6 @@ resource "azurerm_mysql_flexible_server" "gitea" {
   resource_group_name          = data.azurerm_resource_group.ws.name
   location                     = data.azurerm_resource_group.ws.location
   administrator_login          = "mysqladmin"
-  administrator_login_password = random_password.password.result
   sku_name                     = local.sql_sku[var.sql_sku].value
   version                      = "8.0.21"
   backup_retention_days        = 7


### PR DESCRIPTION
#3540 

## What is being addressed

Single Server is retiring in favour of Flexible server so updating azurerm_mysql_server to azurerm_mysql_flexible_server

## How is this addressed

- Update terraform files referencing azurerm_mysql_server to azurerm_mysql_flexible_server.
- sku_name changes
